### PR TITLE
Switch top-level API to use erlang:error/2, to make errors reproducible from one stacktrace

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -76,7 +76,7 @@ decoder(OptsList) ->
 json_to_term(JSON) ->
     try json_to_term(JSON, [])
     %% rethrow exception so internals aren't confusingly exposed to users
-    catch error:badarg -> erlang:error(badarg)
+    catch error:badarg -> erlang:error(badarg,[JSON])
     end.
     
 
@@ -91,7 +91,7 @@ json_to_term(JSON, Opts) ->
 term_to_json(JSON) ->
     try term_to_json(JSON, [])
     %% rethrow exception so internals aren't confusingly exposed to users
-    catch error:badarg -> erlang:error(badarg)
+    catch error:badarg -> erlang:error(badarg,[JSON])
     end.
 
 
@@ -100,7 +100,7 @@ term_to_json(JSON) ->
 term_to_json(JSON, Opts) ->
     try jsx_eep0018:term_to_json(JSON, Opts)
     %% rethrow exception so internals aren't confusingly exposed to users
-    catch error:badarg -> erlang:error(badarg)
+    catch error:badarg -> erlang:error(badarg,[JSON,Opts])
     end.
 
 


### PR DESCRIPTION
Passing a list of arguments in the second parameter, makes them show up in the stack trace in place of the function arity number.

For referentially transparent functions (which foo_to_bar tend to be) failures can then be reproduced from just the stack trace!

If using error/1, you must rely on some higher layer to add enough info to reproduce the crash.
