### PR TITLE
Added typespecs on all exported functions, and fixed 

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -63,8 +63,14 @@ encode(Source, Config) -> jsx_to_json:to_json(Source, Config).
 
 %% old api, alias for encode/x
 
+-spec to_json(Source::json_term()) -> json_text() | {incomplete, encoder()}.
+-spec to_json(Source::json_term(), Config::jsx_to_json:config()) -> json_text() | {incomplete, encoder()}.
+
 to_json(Source) -> encode(Source, []).
 to_json(Source, Config) -> encode(Source, Config).
+
+-spec term_to_json(Source::json_term()) -> json_text() | {incomplete, encoder()}.
+-spec term_to_json(Source::json_term(), Config::jsx_to_json:config()) -> json_text() | {incomplete, encoder()}.
 term_to_json(Source) -> encode(Source, []).
 term_to_json(Source, Config) -> encode(Source, Config).
 
@@ -94,8 +100,15 @@ decode(Source, Config) -> jsx_to_term:to_term(Source, Config).
 
 %% old api, alias for to_term/x
 
+-spec to_term(Source::json_text()) -> json_term() | {incomplete, decoder()}.
+-spec to_term(Source::json_text(), Config::jsx_to_term:config()) -> json_term()  | {incomplete, decoder()}.
+
 to_term(Source) -> decode(Source, []).
 to_term(Source, Config) -> decode(Source, Config).
+
+-spec json_to_term(Source::json_text()) -> json_term() | {incomplete, decoder()}.
+-spec json_to_term(Source::json_text(), Config::jsx_to_term:config()) -> json_term()  | {incomplete, decoder()}.
+
 json_to_term(Source) -> decode(Source, []).
 json_to_term(Source, Config) -> decode(Source, Config).
 

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -35,8 +35,11 @@
 
 
 %% parsing of jsx config
+-spec parse_config(Config::proplists:proplist()) -> config().
+
 parse_config(Config) ->
     parse_config(Config, #config{}).
+
 
 parse_config([], Config) ->
     Config;
@@ -101,6 +104,7 @@ parse_config([ignore_bad_escapes|Rest], Config) ->
 parse_config(Options, Config) ->
     erlang:error(badarg, [Options, Config]).
 
+-spec config_to_list(Config::config()) -> proplists:proplist().
 
 config_to_list(Config) ->
     lists:map(
@@ -115,6 +119,7 @@ config_to_list(Config) ->
         )
     ).
 
+-spec valid_flags() -> [atom()].
 
 valid_flags() ->
     [
@@ -141,6 +146,7 @@ valid_flags() ->
         ignore_bad_escapes      %% ignored_bad_escapes
     ].
 
+-spec extract_config(Config::proplists:proplist()) -> proplists:proplist().
 
 extract_config(Config) ->
     extract_parser_config(Config, []).

--- a/src/jsx_config.hrl
+++ b/src/jsx_config.hrl
@@ -12,3 +12,5 @@
     error_handler = false,
     incomplete_handler = false
 }).
+
+-type config() :: #config{}.

--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -48,7 +48,7 @@ decoder(Handler, State, Config) ->
         Acc::any(),
         Stack::list(atom()),
         Config::jsx:config()
-    ) -> jsx:decoder().
+    ) -> jsx:decoder() | {incomplete, _}.
 
 resume(Rest, State, Handler, Acc, Stack, Config) ->
     case State of

--- a/src/jsx_parser.erl
+++ b/src/jsx_parser.erl
@@ -36,12 +36,12 @@ parser(Handler, State, Config) ->
 %% resume allows continuation from interrupted decoding without having to explicitly export
 %%  all states
 -spec resume(
-        Rest::binary(),
+        Rest::list(), %% was binary(),
         State::atom(),
         Handler::{atom(), any()},
         Stack::list(atom()),
         Config::jsx:config()
-    ) -> jsx:parser().
+    ) -> jsx:parser() | {incomplete, _}.
 
 resume(Rest, State, Handler, Stack, Config) ->
     case State of
@@ -208,7 +208,11 @@ clean_string(Bin, Tokens, Handler, Stack, Config) ->
 
 
 %% for raw input
+-spec init(proplists:proplist()) -> list().
+
 init([]) -> [].
+
+-spec handle_event(Event::any(), Acc::list()) -> list().
 
 handle_event(end_json, State) -> lists:reverse(State);
 handle_event(Event, State) -> [Event] ++ State.

--- a/src/jsx_to_json.erl
+++ b/src/jsx_to_json.erl
@@ -34,6 +34,7 @@
 }).
 
 -type config() :: list().
+-export_type([config/0]).
 
 
 -spec to_json(Source::any(), Config::config()) -> binary().
@@ -85,10 +86,12 @@ parse_config([], Config) ->
 -define(newline, <<"\n">>).
 
 
+-type state() :: {any(), unicode:charlist(), #config{}}.
+-spec init(Config::proplists:proplist()) -> state().
 
 init(Config) -> {start, [], parse_config(Config)}.
 
-
+-spec handle_event(Event::any(), State::state()) -> state().
 
 handle_event(Event, {start, Acc, Config}) ->
     case Event of

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -33,6 +33,8 @@
 }).
 
 -type config() :: list().
+-export_type([config/0]).
+
 
 -type json_value() :: list({binary(), json_value()})
     | list(json_value())
@@ -72,9 +74,12 @@ parse_config([K|Rest] = Options, Config) ->
 parse_config([], Config) ->
     Config.
 
+-type state() :: {[any()], #config{}}.
+-spec init(Config::proplists:proplist()) -> state().
 
 init(Config) -> {[[]], parse_config(Config)}.
 
+-spec handle_event(Event::any(), State::state()) -> state().
 
 handle_event(end_json, {[[Terms]], _Config}) -> Terms;
 

--- a/src/jsx_verify.erl
+++ b/src/jsx_verify.erl
@@ -32,6 +32,7 @@
 }).
 
 -type config() :: [].
+-export_type([config/0]).
 
 
 -spec is_json(Source::binary(), Config::config()) -> true | false.
@@ -72,9 +73,13 @@ parse_config([K|Rest] = Options, Config) ->
 parse_config([], Config) ->
     Config.
 
+-type state() :: {#config{}, any()}.
+-spec init(Config::proplists:proplist()) -> state().
 
 init(Config) -> {parse_config(Config), []}.
 
+
+-spec handle_event(Event::any(), State::state()) -> state().
 
 handle_event(end_json, _) -> true;
 


### PR DESCRIPTION
Made sure all exported types do have a typespec. This is useful in build scenarios where the following erlang compile options are used:

```
[warn_missing_spec, warnings_as_errors]
```

A few type errors found by Dialyzer are corrected: 
- `jsx_decoder:resume/6` and `jsx_parser:resume/5` have gotten an `incomplete`-tuple alternative as return value. 
- The type of the second argument to `jsx_parser:resume/5` have been changed to `list()`.
