### PR TITLE
handle  jsx:encode([{key,value}])

### DIFF
--- a/src/jsx_encoder.erl
+++ b/src/jsx_encoder.erl
@@ -68,6 +68,8 @@ value(Int, {Handler, State}, _Config) when is_integer(Int) ->
 value(Literal, {Handler, State}, _Config)
         when Literal == true; Literal == false; Literal == null ->
     Handler:handle_event({literal, Literal}, State);
+value(String, {Handler, State}, Config) when is_atom(String) ->
+    Handler:handle_event({string, clean_string(atom_to_binary(String,latin1), {Handler, State}, Config)}, State);
 value([{}], {Handler, State}, _Config) ->
     Handler:handle_event(end_object, Handler:handle_event(start_object, State));
 value([], {Handler, State}, _Config) ->
@@ -163,6 +165,7 @@ encode(Term, Config) -> start(Term, {jsx, []}, jsx_config:parse_config(Config)).
 pre_encoders_test_() ->
     Term = [
         {<<"object">>, [
+            {atomkey, atomvalue},
             {<<"literals">>, [true, false, null]},
             {<<"strings">>, [<<"foo">>, <<"bar">>, <<"baz">>]},
             {<<"numbers">>, [1, 1.0, 1.0e0]}
@@ -173,6 +176,7 @@ pre_encoders_test_() ->
             [
                 start_object,
                     {key, <<"object">>}, start_object,
+                        {key, <<"atomkey">>}, {string, <<"atomvalue">>},
                         {key, <<"literals">>}, start_array,
                             {literal, true}, {literal, false}, {literal, null},
                         end_array,
@@ -192,6 +196,7 @@ pre_encoders_test_() ->
             [
                 start_object,
                     {key, <<"object">>}, start_object,
+                        {key, <<"atomkey">>}, {string, <<"atomvalue">>},
                         {key, <<"literals">>}, start_array, end_array,
                         {key, <<"strings">>}, start_array, end_array,
                         {key, <<"numbers">>}, start_array, end_array,
@@ -213,6 +218,7 @@ pre_encoders_test_() ->
             [
                 start_object,
                     {key, <<"object">>}, start_object,
+                        {key, <<"atomkey">>}, {literal, false},
                         {key, <<"literals">>}, start_array,
                             {literal, false}, {literal, false}, {literal, false},
                         end_array,
@@ -232,6 +238,7 @@ pre_encoders_test_() ->
             [
                 start_object,
                     {key, <<"object">>}, start_object,
+                        {key, <<"atomkey">>}, {string, <<"atomvalue">>},
                         {key, <<"literals">>}, start_array,
                             {string, <<"true">>}, {string, <<"false">>}, {string, <<"null">>},
                         end_array,


### PR DESCRIPTION
I've made a fix with some tests.

Now it is possible to encode proplists with atoms as values.
