### PR TITLE
Allow integer object keys when converting term to json

### DIFF
--- a/src/jsx_encoder.erl
+++ b/src/jsx_encoder.erl
@@ -128,7 +128,7 @@ pre_encode(Value, Config) -> (Config#config.pre_encode)(Value).
 
 
 fix_key(Key) when is_atom(Key) -> fix_key(atom_to_binary(Key, utf8));
-fix_key(Key) when is_integer(Key) -> fix_key(integer_to_binary(Key));
+fix_key(Key) when is_integer(Key) -> fix_key(list_to_binary(integer_to_list(Key)));
 fix_key(Key) when is_binary(Key) -> Key.
 
 


### PR DESCRIPTION
Allow integer object keys when converting term to json i.e. automatic conversion from integer to binary.
Some existing implementations (Python, Ruby) tolerate integer keys by converting them to string automatically.
Example of what this patch allows to do:

```
2> jsx:encode([{123, [{456,789}]}]).
<<"{\"123\":{\"456\":789}}">>
3>
```

Conversion is not symmetric, works only for term to json direction.
