### PR TITLE
Fix dialyzer with maps_support

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -41,11 +41,22 @@
 -endif.
 
 
+-ifndef(maps_support).
 -type json_term() :: [{binary() | atom(), json_term()}] | [{}]
     | [json_term()] | []
     | true | false | null
     | integer() | float()
     | binary() | atom().
+-endif.
+
+-ifdef(maps_support).
+-type json_term() :: [{binary() | atom(), json_term()}] | [{}]
+    | [json_term()] | []
+    | map()
+    | true | false | null
+    | integer() | float()
+    | binary() | atom().
+-endif.
 
 -type json_text() :: binary().
 


### PR DESCRIPTION
jsx (and jsxn) failed to pass dialyzer with maps_support, because json_term() does not conain map() in its type description. This PR fixes the problem by adding map() to json_term() if maps_support is defined.
