### PR TITLE
Represent empty array as [empty_array] instead []

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -187,14 +187,14 @@ test_cases() ->
 special_test_cases() -> special_objects() ++ special_array().
 
 
-empty_array() -> [{"[]", <<"[]">>, [], [start_array, end_array]}].
+empty_array() -> [{"[]", <<"[]">>, [empty_array], [start_array, end_array]}].
 
 
 nested_array() ->
     [{
         "[[[]]]",
         <<"[[[]]]">>,
-        [[[]]],
+        [[[empty_array]]],
         [start_array, start_array, start_array, end_array, end_array, end_array]
     }].
 
@@ -373,7 +373,7 @@ special_objects() ->
 
 
 special_array() ->
-    [    
+    [
         {
             "[foo, bar]",
             <<"[\"foo\",\"bar\"]">>,

--- a/src/jsx_encoder.erl
+++ b/src/jsx_encoder.erl
@@ -52,6 +52,7 @@ encode(Term, EntryPoint) when is_map(Term) ->
 encode(Term, EntryPoint) -> encode_(Term, EntryPoint).
 -endif.
 
+encode_([empty_array], _EntryPoint) -> [start_array, end_array];
 encode_([], _EntryPoint) -> [start_array, end_array];
 encode_([{}], _EntryPoint) -> [start_object, end_object];
 

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -126,7 +126,7 @@ start_term(Config) when is_list(Config) -> {[], parse_config(Config)}.
 start_object({Stack, Config}) -> {[{object, []}] ++ Stack, Config}.
 
 %% allocate a new array on top of the stack
-start_array({Stack, Config}) -> {[{array, []}] ++ Stack, Config}.
+start_array({Stack, Config}) -> {[{array, [empty_array]}] ++ Stack, Config}.
 
 %% finish an object or array and insert it into the parent object if it exists or
 %%  return it if it is the root object
@@ -145,6 +145,8 @@ insert(Key, {[{object, Pairs}|Rest], Config}) ->
     {[{object, Key, Pairs}] ++ Rest, Config};
 insert(Value, {[{object, Key, Pairs}|Rest], Config}) ->
     {[{object, [{Key, Value}] ++ Pairs}] ++ Rest, Config};
+insert(Value, {[{array, [empty_array]}|Rest], Config}) ->
+    {[{array, [Value]}] ++ Rest, Config};
 insert(Value, {[{array, Values}|Rest], Config}) ->
     {[{array, [Value] ++ Values}] ++ Rest, Config};
 insert(_, _) -> erlang:error(badarg).
@@ -226,11 +228,11 @@ rep_manipulation_test_() ->
             start_object({[{object, []}], #config{}})
         )},
         {"allocate a new array on an empty stack", ?_assertEqual(
-            {[{array, []}], #config{}},
+            {[{array, [empty_array]}], #config{}},
             start_array({[], #config{}})
         )},
         {"allocate a new array on a stack", ?_assertEqual(
-            {[{array, []}, {object, []}], #config{}},
+            {[{array, [empty_array]}, {object, []}], #config{}},
             start_array({[{object, []}], #config{}})
         )},
         {"insert a key into an object", ?_assertEqual(
@@ -247,7 +249,7 @@ rep_manipulation_test_() ->
         )},
         {"try to get key from array", ?_assertError(
             badarg,
-            get_key({[{array, []}], #config{}})
+            get_key({[{array, [empty_array]}], #config{}})
         )},
         {"insert a value into an object", ?_assertEqual(
             {[{object, [{key, value}]}, junk], #config{}},
@@ -255,7 +257,7 @@ rep_manipulation_test_() ->
         )},
         {"insert a value into an array", ?_assertEqual(
             {[{array, [value]}, junk], #config{}},
-            insert(value, {[{array, []}, junk], #config{}})
+            insert(value, {[{array, [empty_array]}, junk], #config{}})
         )},
         {"insert a key/value pair into an object", ?_assertEqual(
             {[{object, [{key, value}, {x, y}]}, junk], #config{}},


### PR DESCRIPTION
In erlang empty string and lists are represented in the same way.
In order to distinguish [] from "" put an 'empty_array' atom inside
erlang list. It will pass is_list guards and will be different from
empty string.

This is fix to my problem of executing following flow:
json -> terms -> sql. SQL builder doesn't know when to use array
constructor.. because it gets [] and treats it as a string.

This is totally not JSON standard, so I doubt it will get in.
I wonder what would be your approach to this problem.
