### PR TITLE
fixed -0e0 decoding crash with test

### DIFF
--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -892,6 +892,8 @@ number(Bin, Handler, Acc, [State|Stack], Config) ->
 
 
 zero(<<?decimalpoint, Rest/binary>>, N) -> initialdecimal(Rest, N + 1);
+zero(<<$e, _/binary>>, N) -> {integer, N};
+zero(<<$E, _/binary>>, N) -> {integer, N};
 zero(<<>>, N) -> {zero, N};
 zero(_, N) -> {finish_integer, N}.
 
@@ -1171,6 +1173,7 @@ special_number_test_() ->
         {"0e4", [{float, 0.0}, end_json], <<"0e4">>},
         {"1e0", [{float, 1.0}, end_json], <<"1e0">>},
         {"-1e0", [{float, -1.0}, end_json], <<"-1e0">>},
+        {"-0e0", [{float, -0.0}, end_json], <<"-0e0">>},
         {"1e4", [{float, 1.0e4}, end_json], <<"1e4">>},
         {"number terminated by whitespace", 
             [start_array, {integer, 1}, end_array, end_json],


### PR DESCRIPTION
Hi,

First off, great job with JSX!

I am still a newbie with JSON and JSX, but this looked like a bug to me and here is my attempt to fix. This is quite a trivial bug.

`JSON.parse("-0e0")` works in browser but `jsx:decode(<<"-0e0">>)` fails:

```erlang
> jsx:decode(<<"-0e0">>).
** exception error: bad argument
     in function  jsx_decoder:done/4 (jsx_decoder.erl, line 1135)
```

With this pull request:
```erlang
> jsx:decode(<<"-0e0">>).
0.0
```

If my interpretation is incorrect, I hope to learn from feedback.

Thanks.