### PR TITLE
Always add maps_support to mix compiled build

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,8 +13,8 @@ use Mix.Project
     ]
   end
 
-  defp opts(:dev), do: [d: :TEST]
-  defp opts(_), do: []
+  defp opts(:dev), do: [d: :TEST] ++ opts(:prod)
+  defp opts(_), do: [d: :maps_support, d: :maps_always]
 
   defp deps(_), do: [{:mixunit, git: "git@github.com:talentdeficit/mixunit.git", only: :dev}]
 


### PR DESCRIPTION
As elixir supports only from erlang 17, it should ships with maps_support.