### PR TITLE
Add return_tail option

### DIFF
--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -65,6 +65,8 @@ parse_config([dirty_strings|Rest], Config) ->
     parse_config(Rest, Config#config{dirty_strings=true});
 parse_config([multi_term|Rest], Config) ->
     parse_config(Rest, Config#config{multi_term=true});
+parse_config([return_tail|Rest], Config) ->
+    parse_config(Rest, Config#config{return_tail=true});
 %% retained for backwards compat, now does nothing however
 parse_config([repeat_keys|Rest], Config) ->
     parse_config(Rest, Config);
@@ -155,6 +157,7 @@ valid_flags() ->
         unescaped_jsonp,
         dirty_strings,
         multi_term,
+        return_tail,
         repeat_keys,
         strict,
         stream,
@@ -196,6 +199,7 @@ config_test_() ->
                     unescaped_jsonp = true,
                     dirty_strings = true,
                     multi_term = true,
+                    return_tail = true,
                     strict_comments = true,
                     strict_commas = true,
                     strict_utf8 = true,
@@ -209,6 +213,7 @@ config_test_() ->
                     escaped_strings,
                     unescaped_jsonp,
                     multi_term,
+                    return_tail,
                     repeat_keys,
                     strict,
                     stream,

--- a/src/jsx_config.hrl
+++ b/src/jsx_config.hrl
@@ -9,6 +9,7 @@
     strict_single_quotes = false        :: boolean(),
     strict_escapes = false              :: boolean(),
     stream = false                      :: boolean(),
+    return_tail = false                 :: boolean(),
     uescape = false                     :: boolean(),
     unescaped_jsonp = false             :: boolean(),
     error_handler = false               :: false | jsx_config:handler(),


### PR DESCRIPTION
I've added a new option to return unparsed prefix.
It's useful for example to parse stream. One of examples of such stream is [Docker's stats API](https://docs.docker.com/reference/api/docker_remote_api_v1.17/).
It streams objects without separators. It's hard to split them without parsing.

Examples
-----

```erlang
3> jsx:decode(<<"{} 3">>, [return_tail]).                                            
{with_tail,[{}],<<"3">>}                                                             
                                                                                     
4> {incomplete, F} = jsx:decode(<<"{">>, [return_tail, stream]).                     
{incomplete,#Fun<jsx_decoder.1.79655427>}                                            
                                                                                     
5> F(<<"} 3">>).                                                                     
{with_tail,[{}],<<"3">>}                                                             
                                                                                     
6> F(<<"\"key\":\"value\"} 3">>).                                                    
{with_tail,[{<<"key">>,<<"value">>}],<<"3">>} 
```