### PR TITLE
Match jsx:json_term() / jsx_to_term:json_value() specs for empty object.

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -44,7 +44,7 @@
 
 
 -ifndef(maps_support).
--type json_term() :: [{binary() | atom(), json_term()}] | [{}]
+-type json_term() :: [{binary() | atom(), json_term()}] | [{},...]
     | [json_term()] | []
     | true | false | null
     | integer() | float()
@@ -53,7 +53,7 @@
 -endif.
 
 -ifdef(maps_support).
--type json_term() :: [{binary() | atom(), json_term()}] | [{}]
+-type json_term() :: [{binary() | atom(), json_term()}] | [{},...]
     | [json_term()] | []
     | map()
     | true | false | null

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -46,7 +46,7 @@
 
 -ifndef(maps_support).
 -type json_value() :: list(json_value())
-    | list({binary() | atom(), json_value()})
+    | list({binary() | atom(), json_value()}) | [{},...]
     | true
     | false
     | null
@@ -57,7 +57,7 @@
 
 -ifdef(maps_support).
 -type json_value() :: list(json_value())
-    | list({binary() | atom(), json_value()})
+    | list({binary() | atom(), json_value()}) | [{},...]
     | map()
     | true
     | false


### PR DESCRIPTION
The current specs trigger dialyzer warnings when trying to match an empty object. For example:
<pre lang="erlang">
[{}] = jsx:decode(<<"{}">>).
</pre>