### PR TITLE
fix mix.exs warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ use Mix.Project
       version: "2.8.0",
       description: "an erlang application for consuming, producing and manipulating json. inspired by yajl",
       deps: deps(Mix.env),
-      package: package,
+      package: package(),
       language: :erlang,
       erlc_options: opts(Mix.env)
     ]


### PR DESCRIPTION
elixir 1.4.0
fix warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /home/ ... /deps/jsx/mix.exs:10