### PR TITLE
Add debug_info to rebar.config.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
-{edoc_opts, [{preprocess, true}]},
+{edoc_opts, [{preprocess, true}]}.
 {erl_opts, [debug_info]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,2 @@
-{edoc_opts, [{preprocess, true}]}.
+{edoc_opts, [{preprocess, true}]},
+{erl_opts, [debug_info]}.


### PR DESCRIPTION
As reported (not primary issue) in jeremyjh/dialyxir#56 .

`debug_info` should be included in rebar by default but it looks like it is being dropped in the rebar script. Adding it  resolves the issue.