### PR TITLE
jsx_to_term:parse_config/2: Honor `return_maps` option value

### DIFF
--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -88,7 +88,7 @@ parse_config([labels|Rest], Config) ->
     parse_config(Rest, Config#config{labels = binary});
 parse_config([{return_maps, Val}|Rest], Config)
         when Val == true; Val == false ->
-    parse_config(Rest, Config#config{return_maps = true});
+    parse_config(Rest, Config#config{return_maps = Val});
 parse_config([return_maps|Rest], Config) ->
     parse_config(Rest, Config#config{return_maps = true});
 parse_config([{K, _}|Rest] = Options, Config) ->
@@ -423,6 +423,10 @@ return_maps_test_() ->
         {"an empty map", ?_assertEqual(
             [{}],
             jsx:decode(<<"{}">>, [])
+        )},
+        {"an empty map", ?_assertEqual(
+            [{}],
+            jsx:decode(<<"{}">>, [{return_maps, false}])
         )},
         {"a small map", ?_assertEqual(
             #{<<"awesome">> => true, <<"library">> => <<"jsx">>},


### PR DESCRIPTION
Previously, no matter what the caller specified in options, `return_maps` was always set to `true`. The only solution was to not specify `return_maps` at all.

Unfortunately, if the caller is using a wrapper which sets default options, including `return_maps`, it's impossible to override it. This prevented the caller from requesting this mode if he was interested in preserving the order of keys.

While here, add a testcase for this.
