### PR TITLE
Fix as per dialyzer warning

### DIFF
--- a/src/jsx_consult.erl
+++ b/src/jsx_consult.erl
@@ -80,7 +80,7 @@ consult(File, Config) when is_list(Config) ->
     end.
 
 
--type state() :: {list(), #config{}}.
+-type state() :: {list(), proplists:proplist(), {[], #config{}}}.
 -spec init(Config::proplists:proplist()) -> state().
 
 init(Config) -> {[], Config, jsx_to_term:start_term(Config)}.

--- a/src/jsx_verify.erl
+++ b/src/jsx_verify.erl
@@ -27,7 +27,7 @@
 -export([init/1, handle_event/2]).
 
 
--spec is_json(Source::binary(), Config::jsx_config:config()) -> true | false | {incomplete, jsx:decoder()}.
+-spec is_json(Source::binary(), Config::proplists:proplist()) -> true | false | {incomplete, jsx:decoder()}.
 
 is_json(Source, Config) when is_list(Config) ->
     try (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config)))(Source)
@@ -35,7 +35,7 @@ is_json(Source, Config) when is_list(Config) ->
     end.
 
 
--spec is_term(Source::any(), Config::jsx_config:config()) -> true | false | {incomplete, jsx:encoder()}.
+-spec is_term(Source::any(), Config::proplists:proplist()) -> true | false | {incomplete, jsx:encoder()}.
 
 is_term(Source, Config) when is_list(Config) ->
     try (jsx:encoder(?MODULE, Config, jsx_config:extract_config(Config)))(Source)


### PR DESCRIPTION
I'm still missing a warning, though...

```
src/jsx_decoder.erl
 764: Guard test fun((atom() | binary() | [atom() | binary() | [any()] | number() | {} | {atom() | binary() | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},atom() | binary() | [any()] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | {byte(),byte(),byte()} | #{}} | #{}] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | #{},{'encoder',_,atom() | tuple()} | {'parser',_,atom() | tuple(),[any()]} | {'decoder',_,atom() | tuple(),'null' | [any()],[any()]},[atom() | {'error_handler',fun((atom() | binary() | [atom() | binary() | [any()] | number() | {} | {atom() | binary() | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},atom() | binary() | [any()] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | {byte(),byte(),byte()} | #{}} | #{}] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | #{},{'encoder',_,atom() | tuple()} | {'parser',_,atom() | tuple(),[any()]} | {'decoder',_,atom() | tuple(),'null' | [any()],[any()]},[atom() | {'error_handler',_} | {'incomplete_handler',_} | {'pre_encode',fun((_) -> any())}]) -> any())} | {'incomplete_handler',fun((atom() | binary() | [atom() | binary() | [any()] | number() | {} | {atom() | binary() | {non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},atom() | binary() | [any()] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | {byte(),byte(),byte()} | #{}} | #{}] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | #{},{'encoder',_,atom() | tuple()} | {'parser',_,atom() | tuple(),[any()]} | {'decoder',_,atom() | tuple(),'null' | [any()],[any()]},[atom() | {'error_handler',_} | {'incomplete_handler',_} | {'pre_encode',fun((_) -> any())}]) -> any())} | {'pre_encode',fun((_) -> any())}]) -> any()) =:= F::byte() can never succeed
```