### PR TITLE
Support custom newline symbol(s) for format option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ erl_crash.dump
 .DS_Store
 doc
 .rebar
+*.sublime-*
+rebar3
+_build/
+

--- a/README.md
+++ b/README.md
@@ -572,8 +572,9 @@ format(JSON) -> JSON
 format(JSON, Opts) -> JSON
 
   JSON = json_text()
-  Opts = [option() | space | {space, N} | indent | {indent, N}]
-    N = pos_integer()
+  Opts = [option() | space | {space, N} | indent | {indent, N} | {newline, LF}]
+     N = pos_integer()
+    LF = binary()
 ```
 
 `format` parses a json text (a `utf8` encoded binary) and produces a new json 
@@ -585,6 +586,9 @@ json output. `space` is an alias for `{space, 1}`. the default is `{space, 0}`
 the option `{indent, N}` inserts a newline and `N` spaces for each level of 
 indentation in your json output. note that this overrides spaces inserted after 
 a comma. `indent` is an alias for `{indent, 1}`. the default is `{indent, 0}`
+
+the option `{newline, LF}` defines a custom newline symbol(s). 
+the default is `{newline, <<$\n>>}`
 
 raises a `badarg` error exception if input is not valid json
 


### PR DESCRIPTION
__WHY__

The feature is required to support proper multi-line logging of JSON content is lambda functions.
See stack overflow discussion

https://stackoverflow.com/questions/47446002/how-does-multi-line-logging-work-in-lambda-cloudwatch

AWS CloudWatch renders multi-line JSON (property) if `\n` is replaced with `\r`.
Since, the library supports already format(ing) and pretty printing, then  a new option to customise `newline` symbol fits nicely there

__WHAT__

* new option `newline` to format function is added.
