### PR TITLE
Fix error and `-spec(_).`s

### DIFF
--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -43,7 +43,7 @@ decoder(Handler, State, Config) ->
 -spec resume(
         Rest::binary(),
         State::atom(),
-        Handler::{atom(), any()},
+        Handler::module(),
         Acc::any(),
         Stack::list(atom()),
         Config::jsx:config()

--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -695,13 +695,13 @@ unescape(<<$u, F, A, B, C, ?rsolidus, $u, G, X, Y, Z, Rest/binary>>, Handler, Ac
     Low = erlang:list_to_integer([$d, X, Y, Z], 16),
     Codepoint = (High - 16#d800) * 16#400 + (Low - 16#dc00) + 16#10000,
     string(Rest, Handler, [Acc, <<Codepoint/utf8>>], Stack, Config);
-unescape(<<$u, F, A, B, C, ?rsolidus, $u, W, X, Y, Z, Rest/binary>>, Handler, Acc, Stack, Config)
+unescape(<<$u, F0, A, B, C, ?rsolidus, $u, W, X, Y, Z, Rest/binary>>, Handler, Acc, Stack, Config)
         when (A == $8 orelse A == $9 orelse A == $a orelse A == $b orelse A == $A orelse A == $B),
-            (F == $d orelse F == $D),
+            (F0 == $d orelse F0 == $D),
             ?is_hex(B), ?is_hex(C), ?is_hex(W), ?is_hex(X), ?is_hex(Y), ?is_hex(Z)
         ->
     case Config#config.strict_utf8 of
-        true -> ?error(<<$u, $d, A, B, C, ?rsolidus, $u, W, X, Y, Z, Rest/binary>>, Handler, Acc, Stack, Config);
+        true -> ?error(string, <<$u, $d, A, B, C, ?rsolidus, $u, W, X, Y, Z, Rest/binary>>, Handler, Acc, Stack, Config);
         false -> string(Rest, Handler, [Acc, <<16#fffd/utf8>>, <<16#fffd/utf8>>], Stack, Config)
     end;
 unescape(<<$u, F, A, B, C, ?rsolidus, Rest/binary>>, Handler, Acc, Stack, Config)

--- a/src/jsx_parser.erl
+++ b/src/jsx_parser.erl
@@ -38,7 +38,7 @@ parser(Handler, State, Config) ->
 -spec resume(
         Rest::jsx:token(),
         State::atom(),
-        Handler::{atom(), any()},
+        Handler::module(),
         Stack::list(atom()),
         Config::jsx:config()
     ) -> jsx:parser() | {incomplete, jsx:parser()}.


### PR DESCRIPTION
The third commit (the one that took me the longest to understand, since the `dialyzer` message isn't all that clear), I had already referred to in https://github.com/talentdeficit/jsx/pull/118 and https://github.com/talentdeficit/jsx/pull/123, and it's finally fixed 😃

The two previous commits (regarding the `module()` change) had somehow not surfaced before (or I was otherwise using different `dialyzer` options locally).

I ran `rebar3 dialyzer`, with no issues, on top of:
* OTP 18.3,
* OTP 19.3,
* OTP 20.3,
* OTP 21.3, and
* OTP 22.2