### PR TITLE
Add `with_tail` to `decode` spec

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -46,6 +46,7 @@
 -ifndef(maps_support).
 -type json_term() :: [{binary() | atom(), json_term()}] | [{},...]
     | [json_term()] | []
+    | {with_tail, json_term(), binary()}
     | true | false | null
     | integer() | float()
     | binary() | atom()
@@ -55,6 +56,7 @@
 -ifdef(maps_support).
 -type json_term() :: [{binary() | atom(), json_term()}] | [{},...]
     | [json_term()] | []
+    | {with_tail, json_term(), binary()}
     | #{ binary() | atom() => json_term() }
     | true | false | null
     | integer() | float()

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -47,6 +47,7 @@
 -ifndef(maps_support).
 -type json_value() :: list(json_value())
     | list({binary() | atom(), json_value()}) | [{},...]
+    | {with_tail, json_value(), binary()}
     | true
     | false
     | null
@@ -58,6 +59,7 @@
 -ifdef(maps_support).
 -type json_value() :: list(json_value())
     | list({binary() | atom(), json_value()}) | [{},...]
+    | {with_tail, json_value(), binary()}
     | map()
     | true
     | false


### PR DESCRIPTION
`with_tail` was not defined in the spec and would fail usage of anyone
using this return format

Closes https://github.com/talentdeficit/jsx/issues/136 