### PR TITLE
Fix wrong `-spec().`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,10 @@
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [debug_info]}.
+{dialyzer, [
+    {warnings, [
+        unknown,
+        unmatched_returns,
+        error_handling,
+        underspecs
+    ]}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,3 +8,10 @@
         underspecs
     ]}
 ]}.
+{profiles, [
+    {test, [
+        {dialyzer, [
+            {plt_extra_apps, [eunit]}
+        ]}
+    ]}
+]}.

--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -76,7 +76,7 @@ decode(Source, Config) -> jsx_to_term:to_term(Source, Config).
 
 format(Source) -> format(Source, []).
 
--spec format(Source::json_text(), Config::jsx_to_json:config()) -> json_text() | {incomplete, decoder()}.
+-spec format(Source::json_text(), Config::jsx_to_json:config()) -> any().
 
 format(Source, Config) -> jsx_to_json:format(Source, Config).
 
@@ -382,7 +382,7 @@ special_objects() ->
 
 
 special_array() ->
-    [    
+    [
         {
             "[foo, bar]",
             <<"[\"foo\",\"bar\"]">>,

--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -58,7 +58,7 @@
 
 encode(Source) -> encode(Source, []).
 
--spec encode(Source::json_term(), Config::jsx_to_json:config()) -> json_text() | {incomplete, encoder()}.
+-spec encode(Source::json_term(), Config::jsx_config:parsable_config()) -> json_text() | {incomplete, encoder()}.
 
 encode(Source, Config) -> jsx_to_json:to_json(Source, Config).
 
@@ -67,7 +67,7 @@ encode(Source, Config) -> jsx_to_json:to_json(Source, Config).
 
 decode(Source) -> decode(Source, []).
 
--spec decode(Source::json_text(), Config::jsx_to_term:config()) -> json_term() | {incomplete, decoder()}.
+-spec decode(Source::json_text(), Config::jsx_config:parsable_config()) -> json_term() | {incomplete, decoder()}.
 
 decode(Source, Config) -> jsx_to_term:to_term(Source, Config).
 
@@ -76,7 +76,7 @@ decode(Source, Config) -> jsx_to_term:to_term(Source, Config).
 
 format(Source) -> format(Source, []).
 
--spec format(Source::json_text(), Config::jsx_to_json:config()) -> any().
+-spec format(Source::json_text(), Config::jsx_config:parsable_config()) -> json_text().
 
 format(Source, Config) -> jsx_to_json:format(Source, Config).
 
@@ -91,43 +91,44 @@ minify(Source) -> format(Source, []).
 prettify(Source) -> format(Source, [space, {indent, 2}]).
 
 
--spec is_json(Source::any()) -> boolean().
+-spec is_json(Source::binary()) -> boolean().
 
 is_json(Source) -> is_json(Source, []).
 
--spec is_json(Source::any(), Config::proplists:proplist()) -> boolean() | {incomplete, decoder()}.
+-spec is_json(Source::binary(), Config::jsx_config:parsable_config()) -> boolean() | {incomplete, decoder()}.
 
 is_json(Source, Config) -> jsx_verify:is_json(Source, Config).
 
 
--spec is_term(Source::any()) -> boolean().
+-spec is_term(Source::json_term() | end_stream | end_json) -> boolean().
 
 is_term(Source) -> is_term(Source, []).
 
--spec is_term(Source::any(), Config::proplists:proplist()) -> boolean() | {incomplete, encoder()}.
+-spec is_term(Source::json_term() | end_stream | end_json,
+              Config::jsx_config:parsable_config()) -> boolean() | {incomplete, encoder()}.
 
 is_term(Source, Config) -> jsx_verify:is_term(Source, Config).
 
 
--spec consult(File::file:name_all()) -> list(json_term()).
+-spec consult(File::file:name_all()) -> list(jsx_consult:json_value()).
 
 consult(File) -> consult(File, []).
 
--spec consult(File::file:name_all(), Config::jsx_to_term:config()) -> list(json_term()).
+-spec consult(File::file:name_all(), Config::jsx_consult:config()) -> list(jsx_consult:json_value()).
 
 consult(File, Config) -> jsx_consult:consult(File, Config).
 
 
 -type decoder() :: fun((json_text() | end_stream | end_json) -> any()).
 
--spec decoder(Handler::module(), State::any(), Config::list()) -> decoder().
+-spec decoder(Handler::module(), State::any(), Config::jsx_config:parsable_config()) -> decoder().
 
 decoder(Handler, State, Config) -> jsx_decoder:decoder(Handler, State, Config).
 
 
 -type encoder() :: fun((json_term() | end_stream | end_json) -> any()).
 
--spec encoder(Handler::module(), State::any(), Config::list()) -> encoder().
+-spec encoder(Handler::module(), State::any(), Config::jsx_config:parsable_config()) -> encoder().
 
 encoder(Handler, State, Config) -> jsx_encoder:encoder(Handler, State, Config).
 
@@ -156,13 +157,14 @@ encoder(Handler, State, Config) -> jsx_encoder:encoder(Handler, State, Config).
 
 -type parser() :: fun((token() | end_stream) -> any()).
 
--spec parser(Handler::module(), State::any(), Config::list()) -> parser().
+-spec parser(Handler::module(), State::any(), Config::jsx_config:parsable_config()) -> parser().
 
 parser(Handler, State, Config) -> jsx_parser:parser(Handler, State, Config).
 
 -opaque internal_state() :: tuple().
 
--spec resume(Term::json_text() | token(), InternalState::internal_state(), Config::list()) -> any().
+-spec resume(Term::json_text() | token(), InternalState::internal_state(),
+             Config::jsx_config:parsable_config()) -> jsx:decoder() | {incomplete, jsx:decoder()}.
 
 resume(Term, {decoder, State, Handler, Acc, Stack}, Config) ->
     jsx_decoder:resume(Term, State, Handler, Acc, Stack, jsx_config:parse_config(Config));

--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -95,7 +95,7 @@ prettify(Source) -> format(Source, [space, {indent, 2}]).
 
 is_json(Source) -> is_json(Source, []).
 
--spec is_json(Source::any(), Config::jsx_verify:config()) -> boolean() | {incomplete, decoder()}.
+-spec is_json(Source::any(), Config::proplists:proplist()) -> boolean() | {incomplete, decoder()}.
 
 is_json(Source, Config) -> jsx_verify:is_json(Source, Config).
 
@@ -104,7 +104,7 @@ is_json(Source, Config) -> jsx_verify:is_json(Source, Config).
 
 is_term(Source) -> is_term(Source, []).
 
--spec is_term(Source::any(), Config::jsx_verify:config()) -> boolean() | {incomplete, encoder()}.
+-spec is_term(Source::any(), Config::proplists:proplist()) -> boolean() | {incomplete, encoder()}.
 
 is_term(Source, Config) -> jsx_verify:is_term(Source, Config).
 

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -51,7 +51,7 @@
 
 -type parsable_config() :: [valid_flag()
                           | {valid_flag(), boolean()}
-                          | {strict, comments | utf8 | single_quotes | escapes | control_codes}
+                          | {strict, [comments | utf8 | single_quotes | escapes | control_codes]}
                           | {error_handler, fun((any(), any(), any()) -> ok)}
                           | {incomplete_handler, fun((any(), any(), any()) -> ok)}
                           | {return_maps, boolean()}
@@ -59,7 +59,15 @@
                           | {space, non_neg_integer()}
                           | {indent, non_neg_integer()}
                           | {depth, non_neg_integer()}
-                          | {newline, binary()}].
+                          | {newline, binary()}
+                          | legacy_config_elements()
+                          | {legacy_config_elements(), boolean()}].
+-type legacy_config_elements() :: [strict_comments
+                                 | strict_commas
+                                 | strict_utf8
+                                 | strict_single_quotes
+                                 | strict_escapes
+                                 | strict_control_codes].
 -export_type([parsable_config/0]).
 
 -type valid_flag() :: escaped_forward_slashes

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -49,8 +49,37 @@
 -type config() :: #config{}.
 -export_type([config/0]).
 
+-type parsable_config() :: [valid_flag()
+                          | {valid_flag(), boolean()}
+                          | {strict, comments | utf8 | single_quotes | escapes | control_codes}
+                          | {error_handler, fun((any(), any(), any()) -> ok)}
+                          | {incomplete_handler, fun((any(), any(), any()) -> ok)}
+                          | {return_maps, boolean()}
+                          | {labels, binary | atom | existing_atom | attempt_atom}
+                          | {space, non_neg_integer()}
+                          | {indent, non_neg_integer()}
+                          | {depth, non_neg_integer()}
+                          | {newline, binary()}].
+-export_type([parsable_config/0]).
+
+-type valid_flag() :: escaped_forward_slashes
+                    | escaped_strings
+                    | unescaped_jsonp
+                    | dirty_strings
+                    | multi_term
+                    | return_tail
+                    | repeat_keys
+                    | strict
+                    | stream
+                    | uescape
+                    | error_handler
+                    | incomplete_handler
+                    | space
+                    | indent.
+-type valid_flags() :: [valid_flag(), ...].
+
 %% parsing of jsx config
--spec parse_config(Config::proplists:proplist()) -> config().
+-spec parse_config(Config::parsable_config()) -> config().
 
 parse_config(Config) -> parse_config(Config, #config{}).
 
@@ -116,7 +145,7 @@ parse_strict(_Strict, _Rest, _Config) ->
 
 
 
--spec config_to_list(Config::config()) -> proplists:proplist().
+-spec config_to_list(Config::config()) -> parsable_config().
 
 config_to_list(Config) ->
     reduce_config(lists:map(
@@ -153,7 +182,7 @@ reduce_config([Else|Input], Output, Strict) ->
     reduce_config(Input, [Else] ++ Output, Strict).
 
 
--spec valid_flags() -> [atom()].
+-spec valid_flags() -> valid_flags().
 
 valid_flags() ->
     [
@@ -168,11 +197,13 @@ valid_flags() ->
         stream,
         uescape,
         error_handler,
-        incomplete_handler
+        incomplete_handler,
+        space,
+        indent
     ].
 
 
--spec extract_config(Config::proplists:proplist()) -> proplists:proplist().
+-spec extract_config(Config::parsable_config()) -> parsable_config().
 
 extract_config(Config) ->
     extract_parser_config(Config, []).

--- a/src/jsx_consult.erl
+++ b/src/jsx_consult.erl
@@ -32,7 +32,7 @@
     return_maps = false
 }).
 
--type config() :: list().
+-type config() :: proplists:proplist().
 -export_type([config/0]).
 
 -type json_value() :: list(json_value())
@@ -43,6 +43,7 @@
     | integer()
     | float()
     | binary().
+-export_type([json_value/0]).
 
 opts(Opts) -> [return_maps, multi_term] ++ Opts.
 
@@ -61,8 +62,8 @@ consult(File, Config) when is_list(Config) ->
     end.
 
 
--type state() :: {[], proplists:proplist(), {list(), #config{}}}.
--spec init(Config::proplists:proplist()) -> state().
+-type state() :: {[], config(), {list(), #config{}}}.
+-spec init(Config::config()) -> state().
 
 init(Config) -> {[], Config, jsx_to_term:start_term(Config)}.
 

--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -32,7 +32,7 @@
 -export([decoder/3, resume/6]).
 
 
--spec decoder(Handler::module(), State::any(), Config::list()) -> jsx:decoder().
+-spec decoder(Handler::module(), State::any(), Config::jsx_config:parsable_config()) -> jsx:decoder().
 
 decoder(Handler, State, Config) ->
     fun(JSON) -> start(JSON, {Handler, Handler:init(State)}, [], jsx_config:parse_config(Config)) end.

--- a/src/jsx_encoder.erl
+++ b/src/jsx_encoder.erl
@@ -25,19 +25,19 @@
 
 -export([encoder/3, encode/1, encode/2]).
 
--spec encoder(Handler::module(), State::any(), Config::list()) -> jsx:encoder().
+-spec encoder(Handler::module(), State::any(), Config::jsx_config:parsable_config()) -> jsx:encoder().
 
 encoder(Handler, State, Config) ->
     Parser = jsx:parser(Handler, State, Config),
     fun(Term) -> Parser(encode(Term) ++ [end_json]) end.
 
 
--spec encode(Term::any()) -> any().
+-spec encode(Term::any()) -> [any(), ...].
 
 encode(Term) -> encode(Term, ?MODULE).
 
 
--spec encode(Term::any(), EntryPoint::module()) -> any().
+-spec encode(Term::any(), EntryPoint::module()) -> [any(), ...].
 
 encode(Map, _EntryPoint) when is_map(Map), map_size(Map) < 1 ->
     [start_object, end_object];

--- a/src/jsx_parser.erl
+++ b/src/jsx_parser.erl
@@ -27,7 +27,7 @@
 -export([init/1, handle_event/2]).
 
 
--spec parser(Handler::module(), State::any(), Config::list()) -> jsx:parser().
+-spec parser(Handler::module(), State::any(), Config::jsx_config:parsable_config()) -> jsx:parser().
 
 parser(Handler, State, Config) ->
     fun(Tokens) -> value(Tokens, {Handler, Handler:init(State)}, [], jsx_config:parse_config(Config)) end.
@@ -630,7 +630,7 @@ to_hex(X) -> X + 48.    %% ascii "1" is [49], "2" is [50], etc...
 
 
 %% for raw input
--spec init(proplists:proplist()) -> list().
+-spec init([]) -> [].
 
 init([]) -> [].
 

--- a/src/jsx_to_json.erl
+++ b/src/jsx_to_json.erl
@@ -36,17 +36,16 @@
     newline = <<$\n>>
 }).
 
--type config() :: list().
--export_type([config/0]).
+-type config() :: proplists:proplist().
 
 
--spec to_json(Source::any(), Config::config()) -> binary().
+-spec to_json(Source::jsx:json_term(), Config::jsx_config:parsable_config()) -> binary().
 
 to_json(Source, Config) when is_list(Config) ->
     (jsx:encoder(?MODULE, Config, jsx_config:extract_config(Config ++ [escaped_strings])))(Source).
 
 
--spec format(Source::binary(), Config::config()) -> any().
+-spec format(Source::binary(), Config::jsx_config:parsable_config()) -> jsx:json_text().
 
 format(Source, Config) when is_binary(Source) andalso is_list(Config) ->
     (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config ++ [escaped_strings])))(Source);
@@ -91,7 +90,7 @@ parse_config([], Config) ->
 
 
 -type state() :: {unicode:charlist(), #config{}}.
--spec init(Config::proplists:proplist()) -> state().
+-spec init(Config::config()) -> state().
 
 init(Config) -> {[], parse_config(Config)}.
 

--- a/src/jsx_to_json.erl
+++ b/src/jsx_to_json.erl
@@ -46,7 +46,7 @@ to_json(Source, Config) when is_list(Config) ->
     (jsx:encoder(?MODULE, Config, jsx_config:extract_config(Config ++ [escaped_strings])))(Source).
 
 
--spec format(Source::binary(), Config::config()) -> binary().
+-spec format(Source::binary(), Config::config()) -> any().
 
 format(Source, Config) when is_binary(Source) andalso is_list(Config) ->
     (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config ++ [escaped_strings])))(Source);
@@ -320,7 +320,7 @@ encode_test_() ->
         {"0.0", ?_assert(encode(float, 0.0, #config{}) =:= ["0.0"])},
         {"1.0", ?_assert(encode(float, 1.0, #config{}) =:= ["1.0"])},
         {"-1.0", ?_assert(encode(float, -1.0, #config{}) =:= ["-1.0"])},
-        {"3.1234567890987654321", 
+        {"3.1234567890987654321",
             ?_assert(
                 encode(float, 3.1234567890987654321, #config{}) =:= ["3.1234567890987655"])
         },
@@ -331,23 +331,23 @@ encode_test_() ->
         {"0.00000001", ?_assert(encode(float, 0.00000001, #config{}) =:= ["1.0e-8"])},
         {"1.0e-323", ?_assert(encode(float, 1.0e-323, #config{}) =:= ["1.0e-323"])},
         {"1.0e308", ?_assert(encode(float, 1.0e308, #config{}) =:= ["1.0e308"])},
-        {"min normalized float", 
+        {"min normalized float",
             ?_assert(
                 encode(float, math:pow(2, -1022), #config{}) =:= ["2.2250738585072014e-308"]
             )
         },
-        {"max normalized float", 
+        {"max normalized float",
             ?_assert(
-                encode(float, (2 - math:pow(2, -52)) * math:pow(2, 1023), #config{}) 
+                encode(float, (2 - math:pow(2, -52)) * math:pow(2, 1023), #config{})
                     =:= ["1.7976931348623157e308"]
             )
         },
-        {"min denormalized float", 
+        {"min denormalized float",
             ?_assert(encode(float, math:pow(2, -1074), #config{}) =:= ["5.0e-324"])
         },
-        {"max denormalized float", 
+        {"max denormalized float",
             ?_assert(
-                encode(float, (1 - math:pow(2, -52)) * math:pow(2, -1022), #config{}) 
+                encode(float, (1 - math:pow(2, -52)) * math:pow(2, -1022), #config{})
                     =:= ["2.225073858507201e-308"]
             )
         },
@@ -389,7 +389,7 @@ format_test_() ->
 custom_newline_test_() ->
     [
         {"single key object", ?_assert(
-            jsx:format(<<"{\"k\":\"v\"}">>, [space, {indent, 2}, {newline, <<$\r>>}]) 
+            jsx:format(<<"{\"k\":\"v\"}">>, [space, {indent, 2}, {newline, <<$\r>>}])
                 =:= <<"{\r  \"k\": \"v\"\r}">>)
         }
     ].

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -44,18 +44,7 @@
 -type config() :: list().
 -export_type([config/0]).
 
--type json_value() :: list(json_value())
-    | list({binary() | atom(), json_value()}) | [{},...]
-    | {with_tail, json_value(), binary()}
-    | map()
-    | true
-    | false
-    | null
-    | integer()
-    | float()
-    | binary().
-
--spec to_term(Source::binary(), Config::config()) -> json_value().
+-spec to_term(Source::binary(), Config::config()) -> jsx:json_term() | {incomplete, jsx:decoder()}.
 
 to_term(Source, Config) when is_list(Config) ->
     (jsx:decoder(?MODULE, [return_maps] ++ Config, jsx_config:extract_config(Config)))(Source).

--- a/src/jsx_to_term.erl
+++ b/src/jsx_to_term.erl
@@ -41,10 +41,9 @@
     return_maps = false
 }).
 
--type config() :: list().
--export_type([config/0]).
+-type config() :: proplists:proplist().
 
--spec to_term(Source::binary(), Config::config()) -> jsx:json_term() | {incomplete, jsx:decoder()}.
+-spec to_term(Source::binary(), Config::jsx_config:parsable_config()) -> jsx:json_term() | {incomplete, jsx:decoder()}.
 
 to_term(Source, Config) when is_list(Config) ->
     (jsx:decoder(?MODULE, [return_maps] ++ Config, jsx_config:extract_config(Config)))(Source).
@@ -76,7 +75,7 @@ parse_config([], Config) ->
 
 
 -type state() :: {list(), #config{}}.
--spec init(Config::proplists:proplist()) -> state().
+-spec init(Config::config()) -> state().
 
 init(Config) -> start_term(Config).
 

--- a/src/jsx_verify.erl
+++ b/src/jsx_verify.erl
@@ -26,8 +26,9 @@
 -export([is_json/2, is_term/2]).
 -export([init/1, handle_event/2]).
 
+-type config() :: proplists:proplist().
 
--spec is_json(Source::binary(), Config::proplists:proplist()) -> true | false | {incomplete, jsx:decoder()}.
+-spec is_json(Source::binary(), Config::jsx_config:parsable_config()) -> true | false | {incomplete, jsx:decoder()}.
 
 is_json(Source, Config) when is_list(Config) ->
     try (jsx:decoder(?MODULE, Config, jsx_config:extract_config(Config)))(Source)
@@ -35,7 +36,8 @@ is_json(Source, Config) when is_list(Config) ->
     end.
 
 
--spec is_term(Source::any(), Config::proplists:proplist()) -> true | false | {incomplete, jsx:encoder()}.
+-spec is_term(Source::jsx:json_term() | end_stream | end_json,
+              Config::jsx_config:parsable_config()) -> true | false | {incomplete, jsx:encoder()}.
 
 is_term(Source, Config) when is_list(Config) ->
     try (jsx:encoder(?MODULE, Config, jsx_config:extract_config(Config)))(Source)
@@ -68,7 +70,7 @@ parse_config([], Config) ->
 
 %% we don't actually need any state for this
 -type state() :: [].
--spec init(Config::proplists:proplist()) -> state().
+-spec init(Config::config()) -> state().
 
 init(Config) -> parse_config(Config).
 


### PR DESCRIPTION
This is basically #133 adapted to the most `jsx` recent code (two releases were done, in the meantime, though, and this issue resurfaced).

Cheers to the original implementation 🎉.

[Fix #133]