### PR TITLE
Allow tuples in input terms with the [tuples_to_lists] option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ see below                       | `datetime()`
 *   arrays
 
     json arrays are represented with erlang lists of json values as described 
-    in this section
+    in this section, or by tuples with the `tuples_to_lists`option
 
 *   objects
 
@@ -227,6 +227,7 @@ see below                       | `datetime()`
     erlang datetime tuples (`{{Year, Month, Day}, {Hour, Min, Sec}}`) as returned
     from `erlang:localtime/0` are automatically encoded as [iso8601][iso8601]
     strings and are assumed to be UTC time. no conversion is attempted of json [iso8601][iso8601] strings in decoded json
+
 
 
 ### incomplete input ###
@@ -272,7 +273,8 @@ json_term() = [json_term()]
     | float()
     | binary()
     | atom()
-		| datetime()
+    | datetime()
+    | tuple()
 ```
 
 the erlang representation of json. binaries should be `utf8` encoded, or close 
@@ -318,6 +320,7 @@ option() = dirty_strings
     | return_tail
     | uescape
     | unescaped_jsonp
+    | tuples-to_lists
 
 strict_option() = comments
     | trailing_commas
@@ -495,7 +498,7 @@ encode(Term, Opts) -> JSON
 
   Term = json_term()
   JSON = json_text()
-  Opts = [option() | space | {space, N} | indent | {indent, N}]
+  Opts = [option() | space | {space, N} | indent | {indent, N} | tuples-to_lists]
     N = pos_integer()
 ```
 

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -60,6 +60,7 @@
                 | {indent, non_neg_integer()}
                 | {depth, non_neg_integer()}
                 | {newline, binary()}
+                | {tuples_to_lists, boolean()}
                 | legacy_option()
                 | {legacy_option(), boolean()}.
 -type legacy_option() :: strict_comments
@@ -114,6 +115,8 @@ parse_config([multi_term|Rest], Config) ->
     parse_config(Rest, Config#config{multi_term=true});
 parse_config([return_tail|Rest], Config) ->
     parse_config(Rest, Config#config{return_tail=true});
+parse_config([tuples_to_lists|Rest], Config) ->
+    parse_config(Rest, Config#config{tuples_to_lists = true});
 %% retained for backwards compat, now does nothing however
 parse_config([repeat_keys|Rest], Config) ->
     parse_config(Rest, Config);
@@ -215,7 +218,8 @@ valid_flags() ->
         stream,
         uescape,
         error_handler,
-        incomplete_handler
+        incomplete_handler,
+        tuples_to_lists
     ].
 
 
@@ -259,7 +263,8 @@ config_test_() ->
                     strict_escapes = true,
                     strict_control_codes = true,
                     stream = true,
-                    uescape = true
+                    uescape = true,
+                    tuples_to_lists = true
                 },
                 parse_config([dirty_strings,
                     escaped_forward_slashes,
@@ -270,7 +275,8 @@ config_test_() ->
                     repeat_keys,
                     strict,
                     stream,
-                    uescape
+                    uescape,
+                    tuples_to_lists
                 ])
             )
         },
@@ -342,7 +348,9 @@ config_to_list_test_() ->
                 stream,
                 uescape,
                 unescaped_jsonp,
+                tuples_to_lists,
                 strict
+
             ],
             config_to_list(
                 #config{escaped_forward_slashes = true,
@@ -356,7 +364,8 @@ config_to_list_test_() ->
                     strict_escapes = true,
                     strict_control_codes = true,
                     stream = true,
-                    uescape = true
+                    uescape = true,
+                    tuples_to_lists = true
                 }
             )
         )},

--- a/src/jsx_config.hrl
+++ b/src/jsx_config.hrl
@@ -14,5 +14,6 @@
     uescape = false                     :: boolean(),
     unescaped_jsonp = false             :: boolean(),
     error_handler = false               :: false | jsx_config:handler(),
-    incomplete_handler = false          :: false | jsx_config:handler()
+    incomplete_handler = false          :: false | jsx_config:handler(),
+    tuples_to_lists = false             :: boolean()
 }).

--- a/src/jsx_to_json.erl
+++ b/src/jsx_to_json.erl
@@ -33,7 +33,8 @@
     space = 0,
     indent = 0,
     depth = 0,
-    newline = <<$\n>>
+    newline = <<$\n>>,
+    tuples_to_lists = false
 }).
 
 -type config() :: proplists:proplist().
@@ -62,6 +63,8 @@ parse_config([{indent, Val}|Rest], Config) when is_integer(Val), Val > 0 ->
     parse_config(Rest, Config#config{indent = Val});
 parse_config([indent|Rest], Config) ->
     parse_config(Rest, Config#config{indent = 1});
+parse_config([tuples_to_lists|Rest], Config) ->
+    parse_config(Rest, Config#config{tuples_to_lists = true});
 parse_config([{newline, Val}|Rest], Config) when is_binary(Val) ->
     parse_config(Rest, Config#config{newline = Val});
 parse_config([{K, _}|Rest] = Options, Config) ->


### PR DESCRIPTION
Allow encoding terms containing tuples with the `[tuples_to_lists]` option of the `encode` function. Tuples are encoded as lists just like DateTime objects used to be encoded. No exception is made for the `[{}]` and `[{k, v}, ...]` special cases.

The rationale for this pull is that in newer erlang projects structures represeting key -> value pairs generally move from proplists to maps, `encode` and `decode` functions are not invertible anyway, and transforming manually each and every tuple to list manually before encoding is a tedious job. 

Without this option it is fully compatible with previous versions.
