### PR TITLE
Add arguments when badarg error is raised

### DIFF
--- a/src/jsx_parser.erl
+++ b/src/jsx_parser.erl
@@ -60,7 +60,7 @@ resume(Rest, State, Handler, Stack, Config) ->
 -ifndef(error).
 -define(error(State, Terms, Handler, Stack, Config),
     case Config#config.error_handler of
-        false -> erlang:error(badarg);
+        false -> erlang:error(badarg, Terms);
         F -> F(Terms, {parser, State, Handler, Stack}, jsx_config:config_to_list(Config))
     end
 


### PR DESCRIPTION
Now it's will be possible to get the clue, where is the problem, before it was impossible:

`error: {badarg,[{jsx_parser,value,4,[{file,"/home/jenkins/app/_build/default/lib/jsx/src/jsx_parser.erl"},{line,163}]}, {.....`

