### PR TITLE
Added float_as_string option to prevent losing of precision of float …

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ option() = dirty_strings
     | return_tail
     | uescape
     | unescaped_jsonp
+    | float_as_string
 
 strict_option() = comments
     | trailing_commas
@@ -414,6 +415,13 @@ additional options beyond these. see
     will be parsed incorrectly by some javascript interpreters. by default, 
     these codepoints are escaped (to `\u2028` and `\u2029`, respectively) to 
     retain compatibility. this option simply removes that escaping
+
+- `float_as_string`
+
+  the precision of float values in jsons are not restricted by the IEEE 754 standard.
+  in some cases it is not allowed to lose precision during the decoding of a json structure,
+  this option decodes the float values as strings. this way it possible to handle these values with
+  solutions that preserve precision, like the decimal library.
 
 
 ## exports ##

--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -194,6 +194,9 @@ test_cases() ->
     ++ floats()
     ++ compound_object().
 
+float_as_string_test_cases() ->
+    string_floats().
+
 %% segregate these so we can skip them in `jsx_to_term`
 special_test_cases() -> special_objects() ++ special_array().
 
@@ -303,6 +306,34 @@ naked_floats() ->
         || X <- Raw ++ [ -1 * Y || Y <- Raw ]
     ].
 
+floats_as_string() ->
+    Raw = [
+              "0.0", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9",
+              "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9",
+              "1234567890.0987654321",
+              "0.0e0",
+              "1234567890.0987654321e16",
+              "0.1e0", "0.1e1", "0.1e2", "0.1e4", "0.1e8", "0.1e16", "0.1e308",
+              "1.0e0", "1.0e1", "1.0e2", "1.0e4", "1.0e8", "1.0e16", "1.0e308",
+              "2.2250738585072014e-308",    %% min normalized float
+              "1.7976931348623157e308",     %% max normalized float
+              "5.0e-324",                   %% min denormalized float
+              "2.225073858507201e-308"      %% max denormalized float
+          ],
+    [
+        {
+            X,
+            list_to_binary(X),
+            X,
+            [{string, list_to_binary(X)}]
+        }
+        || X <- Raw
+    ].
+
+string_floats() ->
+    floats_as_string()
+    ++ [ wrap_with_array(Test) || Test <- floats_as_string() ]
+    ++ [ wrap_with_object(Test) || Test <- floats_as_string() ].
 
 floats() ->
     naked_floats()
@@ -425,6 +456,14 @@ incremental_decode(JSON) ->
     ),
     Final(end_stream).
 
+incremental_decode_float_as_string(JSON) ->
+    Final = lists:foldl(
+        fun(Byte, Decoder) -> {incomplete, F} = Decoder(Byte), F end,
+        decoder(jsx, [], [stream, float_as_string]),
+        json_to_bytes(JSON)
+    ),
+    Final(end_stream).
+
 
 incremental_parse(Events) ->
     Final = lists:foldl(
@@ -453,6 +492,14 @@ decode_test_() ->
         || {Title, JSON, _, Events} <- Data
     ].
 
+decode_float_as_string_test_() ->
+    Data = float_as_string_test_cases(),
+    [{Title, ?_assertEqual(Events ++ [end_json], (decoder(?MODULE, [], [float_as_string]))(JSON))}
+     || {Title, JSON, _, Events} <- Data
+    ] ++
+        [{Title ++ " (incremental)", ?_assertEqual(Events ++ [end_json], incremental_decode_float_as_string(JSON))}
+         || {Title, JSON, _, Events} <- Data
+        ].
 
 parse_test_() ->
     Data = test_cases(),

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -60,6 +60,7 @@
                 | {indent, non_neg_integer()}
                 | {depth, non_neg_integer()}
                 | {newline, binary()}
+                | {float_as_string, boolean()}
                 | legacy_option()
                 | {legacy_option(), boolean()}.
 -type legacy_option() :: strict_comments
@@ -114,6 +115,8 @@ parse_config([multi_term|Rest], Config) ->
     parse_config(Rest, Config#config{multi_term=true});
 parse_config([return_tail|Rest], Config) ->
     parse_config(Rest, Config#config{return_tail=true});
+parse_config([float_as_string|Rest], Config) ->
+    parse_config(Rest, Config#config{float_as_string=true});
 %% retained for backwards compat, now does nothing however
 parse_config([repeat_keys|Rest], Config) ->
     parse_config(Rest, Config);
@@ -215,7 +218,8 @@ valid_flags() ->
         stream,
         uescape,
         error_handler,
-        incomplete_handler
+        incomplete_handler,
+        float_as_string
     ].
 
 
@@ -259,7 +263,8 @@ config_test_() ->
                     strict_escapes = true,
                     strict_control_codes = true,
                     stream = true,
-                    uescape = true
+                    uescape = true,
+                    float_as_string = true
                 },
                 parse_config([dirty_strings,
                     escaped_forward_slashes,
@@ -270,7 +275,8 @@ config_test_() ->
                     repeat_keys,
                     strict,
                     stream,
-                    uescape
+                    uescape,
+                    float_as_string
                 ])
             )
         },
@@ -342,6 +348,7 @@ config_to_list_test_() ->
                 stream,
                 uescape,
                 unescaped_jsonp,
+                float_as_string,
                 strict
             ],
             config_to_list(
@@ -356,7 +363,8 @@ config_to_list_test_() ->
                     strict_escapes = true,
                     strict_control_codes = true,
                     stream = true,
-                    uescape = true
+                    uescape = true,
+                    float_as_string = true
                 }
             )
         )},

--- a/src/jsx_config.hrl
+++ b/src/jsx_config.hrl
@@ -13,6 +13,7 @@
     return_tail = false                 :: boolean(),
     uescape = false                     :: boolean(),
     unescaped_jsonp = false             :: boolean(),
+    float_as_string = false             :: boolean(),
     error_handler = false               :: false | jsx_config:handler(),
     incomplete_handler = false          :: false | jsx_config:handler()
 }).


### PR DESCRIPTION
…values during decoding

In financial situations it is not acceptable to lose any precision during the decoding of float values.
Add flag to decode float values as string. This way it is possible to use other libraries to handle them with keeping precision