### PR TITLE
fix: Adds erlang:timestamp() to typespec

### DIFF
--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -48,6 +48,7 @@
     | true | false | null
     | integer() | float()
     | binary() | atom()
+    | erlang:timestamp()
     | calendar:datetime().
 
 -type json_text() :: binary().


### PR DESCRIPTION
This is supported in `jsx_parser` which calls `calendar:now_to_datetime/1` for these timestamps.