### PR TITLE
Fix tests under Erlang 27+

### DIFF
--- a/src/jsx_decoder.erl
+++ b/src/jsx_decoder.erl
@@ -1102,7 +1102,8 @@ special_number_test_() ->
     Cases = [
         % {title, test form, json, opt flags}
         {"-0", [{integer, 0}, end_json], <<"-0">>},
-        {"-0.0", [{float, 0.0}, end_json], <<"-0.0">>},
+        {"0.0", [{float, 0.0}, end_json], <<"0.0">>},
+        {"-0.0", [{float, -0.0}, end_json], <<"-0.0">>},
         {"0e0", [{float, 0.0}, end_json], <<"0e0">>},
         {"0e4", [{float, 0.0}, end_json], <<"0e4">>},
         {"1e0", [{float, 1.0}, end_json], <<"1e0">>},


### PR DESCRIPTION
This patch fixes tests under Erlang 27+.

Reason: https://erlangforums.com/t/in-erlang-otp-27-0-0-will-no-longer-be-exactly-equal-to-0-0/2586